### PR TITLE
Signify pre-game posts

### DIFF
--- a/werewolf/assets/css/bgg.css
+++ b/werewolf/assets/css/bgg.css
@@ -820,6 +820,12 @@ div.addcontent
 	color:            #000000;
 	border:           1px solid #8888FF;
 }
+.forum_table--pregame
+{
+    background-color: #E1E1F1;
+    border:           1px dashed #8888FF;
+    opacity:          80%;
+}
 
 .forum_table td
 {

--- a/werewolf/assets/css/layout/base.css
+++ b/werewolf/assets/css/layout/base.css
@@ -15,6 +15,9 @@ body.body {
     min-height: 300px;
     padding: 30px;
   }
+  .content--wide_screen {
+      max-width: 1400px;
+  }
 }
 
 .page-title {

--- a/werewolf/get_user_post.php
+++ b/werewolf/get_user_post.php
@@ -68,6 +68,7 @@ $first_game_post_article_id = mysql_result($result,0,0);
 </head>
 <body>
 <?php display_menu(); ?>
+<div class="content-wrap"><div class="content content--wide_screen">
 <h2>Cassandra Files for <?=$player;?> in "<?=$game_name;?>" <?=$last_dumped;?></h2>
 <p>Return to <a href="/game/<?=$thread_id;?>">Game Page</a></p>
 <?php
@@ -116,6 +117,8 @@ Posted <?=$row['post_date'];?>
 <?php
 }
 ?>
+</div> <!-- end .content -->
+</div> <!-- end .content-wrap -->
 </body>
 </html>
 <?php

--- a/werewolf/get_user_post.php
+++ b/werewolf/get_user_post.php
@@ -56,6 +56,10 @@ $result = mysql_query($sql);
 $user_id = mysql_result($result,0,0);
 
 }
+// Find game start post
+$first_game_post_sql = "SELECT MIN(article_id) AS first_game_post FROM Posts WHERE game_id = $game_id AND user_id = 306 AND text LIKE '%The Cassandra Automatic Vote Tally System%'";
+$result = mysql_query($first_game_post_sql);
+$first_game_post_article_id = mysql_result($result,0,0);
 ?>
 <html>
 <head>
@@ -82,7 +86,7 @@ if ( $rownum < 1 ) {
 <?php
 while ( $row = mysql_fetch_array($result) ) {
 ?>
-<table cellpadding="1" cellspacing="1" border="0" width="100%" class='forum_table'>
+<table cellpadding="1" cellspacing="1" border="0" width="100%" class='forum_table <?php if ($first_game_post_article_id > $row['article_id']) { ?>forum_table--pregame<?php } ?>'>
 <?php
 if ( $player == 'all'  || $player == 'users' ) {
 ?>


### PR DESCRIPTION
When you're reading ISOs of players, it can be difficult to discern which posts happened pre-game and which ones happened after it started. This update adds some styling to the pre-game posts so a reader can more easily tell the difference. 

<img width="1397" alt="image" src="https://user-images.githubusercontent.com/98636/128090081-5f75eabd-814e-4f26-967c-0f4bf6701406.png">

It also adds some content padding to the view posts page. 