### PR TITLE
Rename language to dusk

### DIFF
--- a/bin/game_function_sub.pl
+++ b/bin/game_function_sub.pl
@@ -77,12 +77,12 @@ sub get_phase_change_message($$$) {
   my $deadline = next_deadline($game_id,$phase,$automod);
 
   $message = "[b][Dawn][/b]\n";
-  $message .= "Lynch will be at $deadline.\n";
+  $message .= "Dusk will be at $deadline.\n";
   $m_message = "\nr{Please don't post until your moderator has posted the results of the night actions.}r\n";
   if ( $phase eq "night" ) {
     $message = "[b][Dusk][/b]\n";
     $message .= "Dawn will be at $deadline.\n";
-    $message .="\nr{Please don't post until your moderator has posted the results of the lynch.}r\n";
+    $message .="\nr{Please don't post until your moderator has posted the results of the day actions.}r\n";
     $m_message = "";
   }
   if ( !$automod ) { $message .= $m_message; }

--- a/bin/get_tally.pl
+++ b/bin/get_tally.pl
@@ -60,11 +60,11 @@ $sth_times->bind_columns(\$lynch_time, \$action_time);
 $sth_times->fetch;
 
 if(defined($lynch_time)) {
-	print "\nLynch time is at [b] $lynch_time [/b]";
+	print "\nDusk is at [b] $lynch_time [/b]";
 }
 
 if(defined($action_time)) {
-	print "\nNight Action deadline is at [b] $action_time [/b]";
+	print "\nDawn is at [b] $action_time [/b]";
 }
 
 print "[/color]";

--- a/bin/get_tally_plain.pl
+++ b/bin/get_tally_plain.pl
@@ -45,11 +45,11 @@ $sth_times->bind_columns(\$lynch_time, \$action_time);
 $sth_times->fetch;
 
 if(defined($lynch_time)) {
-	print "\nLynch time is at $lynch_time";
+	print "\nDusk is at $lynch_time";
 }
 
 if(defined($action_time)) {
-	print "\nNight Action deadline is at $action_time";
+	print "\nDawn is at $action_time";
 }
 
 

--- a/bin/save_automod.pl
+++ b/bin/save_automod.pl
@@ -170,7 +170,7 @@ $time = $sth_time->fetchrow_hashref();
 	  $mech->click_button(name => 'submit');
 	  # Post Dawn if the N0 views are random.
 	  if ( $template->{'random_n0'} eq "yes" ) {
-	    $message = "[b][Dawn][/b]\nThe first lynch will be at ".$game->{'lynch_time'}." provided it is at least 12hrs away.  Other wise it will be tomorrow at that time.";
+	    $message = "[b][Dawn][/b]\nThe first dusk will be at ".$game->{'lynch_time'}." provided it is at least 12hrs away.  Other wise it will be tomorrow at that time.";
 	    system("/opt/werewolf/post_thread.pl \"$bgg_user\" \"$bgg_pswd\" reply $thread_id \"$message\"");
 	  } else {
         $message = "It is Night 0.  If you have N0 orders please do that now.  Dawn will be posted at ".$game->{'na_deadline'}." provided it is at least 4hrs away. Otherwise it will be tomorrow at that time.";

--- a/bin/scan_posts_for_votes.pl
+++ b/bin/scan_posts_for_votes.pl
@@ -255,21 +255,21 @@ sub get_action($$$)
 						print "$article_id,$user_id,,$type,nightfall is invalid,0,$edited\n";
 					}
 				}
-				elsif($type eq "vote" and $votee eq "no lynch")
+				elsif($type eq "vote" and $votee eq "no kill")
 				{
 					if ($game_allow_nolynch eq "Yes") {
-						print "$article_id,$user_id,,$type,No Lynch,$valid,$edited\n";
+						print "$article_id,$user_id,,$type,No Kill,$valid,$edited\n";
 					} else {
-						print "$article_id,$user_id,,$type,No Lynch is invalid,0,$edited\n";
+						print "$article_id,$user_id,,$type,No Kill is invalid,0,$edited\n";
 					}
 				}
 				elsif($type eq "unvote" and $votee eq "all")
 				{
 					print "$article_id,$user_id,,$type,all,$valid,$edited\n";
 				}
-				elsif($type eq "unvote" and $votee eq "no lynch")
+				elsif($type eq "unvote" and $votee eq "no kill")
 				{
-					print "$article_id,$user_id,,$type,No Lynch,$valid,$edited\n";
+					print "$article_id,$user_id,,$type,No Kill,$valid,$edited\n";
 				}
 				elsif($type eq "vote"  and $votee eq "all")
 				{

--- a/werewolf/automod/edit_functions.php
+++ b/werewolf/automod/edit_functions.php
@@ -205,7 +205,7 @@ function expand_priest_type($priest_type) {
 	  return "Priest must choose view";
 	break;
 	case "lynch":
-	  return "Priest gets all lynch deaths automatically";
+	  return "Priest gets all daykill deaths automatically";
 	break;
 	case "all":
 	  return "Priest gets all deaths automatically";
@@ -662,7 +662,7 @@ function create_role_table($template_id,$edit=false,$add=0) {
 	$output .= "Example 2:  Priest should be 'Positive Hit on', 'all', View as: 'Player's Role'.  That will make it show the player's role no matter who is targeted. <br />";
 	$output .= "Note: If you choose 'Player's Role' or 'Player's Side' for what to reveal the negative will return 'You can not determine X's Role' or 'You can not determine X's Side' .<br />";
 	$output .= "If you choose 'Let me Choose' you can specify your own phrase for the positive hit.  (ie, the Y in the above instructions.)<br />";
-	$output .= "Note: If you choose 'Priest Type' above as 'gets (lynch) deaths automatcially' you still need to specify they View Result for the Priest.<br />";
+	$output .= "Note: If you choose 'Priest Type' above as 'gets (daykill) deaths automatcially' you still need to specify they View Result for the Priest.<br />";
 	$output .= "<b>Reveal as:</b>  This lets you adjust per-role what is revealed on their death.  If 'No' is selected in the top table, then this won't matter except for a white hat or if you have a passive priest.<br />";
 	$output .= "<b>Attribute:</b> This lets you specify if the role is Tough, Brutal (can't be hidden), Tinker, or White Hat.  Tough will have to be killed twice, Brutal will get to choose a player to take down when killed (The order command will be created automatically.)  Tinker will make it so that all views are reversed,  If it would have been positive it will now be negative if it would have been negative it will now be positive.  White Hat means the players 'Reveal as' information will be revealed on death regardles.<br />";
 	$output .= "<b>Parity Count:</b>  These are the roles the code will count to see if Parity has been reached.  All wolves should have a 'Yes', you can choose if sorcerers or wolfcubs etc are counted towards parity.<br />";
@@ -812,8 +812,8 @@ function get_ruleset($template_id,$edit=false) {
   if ( $edit ) {
     $output = "<p>Please use BBG formating as this will be the first post Cassy post when the game is created.<br />";
     $output .= "The following will be replaced by user input when the game is created:<br />";
-    $output .= "&lt;lynch&gt; - Lynch Deadline <br />";
-    $output .= "&lt;night&gt; - Nigth Action Deadline <br />";
+    $output .= "&lt;lynch&gt; - Dusk Deadline <br />";
+    $output .= "&lt;night&gt; - Dawn Deadline <br />";
     $output .= "&lt;tiebreaker&gt; - Tie Breaker Type <br />";
     $output .= "<b>IMPORTANT:</b> You can't use \" you must use ' instead.<br /></p>";
     $output .= "<textarea name='my_rules' rows='25' cols='84'>";

--- a/werewolf/automod/new.php
+++ b/werewolf/automod/new.php
@@ -27,10 +27,10 @@ if ( isset($_POST['submit']) ) {
   if ( $_POST['deadline_speed'] == "Standard") {
     $lynch = time_24($_POST['lynch']);
     $lynch_db = $_POST['lynch'];
-    $message .= "Lynch time: ".$lynch."\n";
+    $message .= "Dusk: ".$lynch."\n";
     $night = time_24($_POST['night']);
     $night_db = $_POST['night'];
-    $message .= "Night Action Deadline: ".$night."\n";
+    $message .= "Dawn: ".$night."\n";
     $day_length = "NULL";
     $night_length = "NULL";
   } else {
@@ -131,15 +131,15 @@ function  validate_form() {
    return false
  }
  if ( document.getElementById('lynch').value == "" ) {
-  alert("Lynch time must be filled in")
+  alert("Dusk must be filled in")
   return false
  }
  if ( document.getElementById('night').value == "" ) {
-  alert("Night Action Deadline time must be filled in")
+  alert("Dawn must be filled in")
   return false
  }
  if ( document.getElementById('lynch').value == document.getElementById('night').value ) {
-   alert("Lynch time and Night Action Deadline can not be the same time")
+   alert("Dusk and Dawn can not be the same time")
    return false
  }
  return true
@@ -228,8 +228,8 @@ function show_desc() {
   <td>
   <div id='deadlines' class='showDiv'>
   <table cellspacing='0' cellpadding='0'>
-  <tr><td>Lynch Time:</td><td><?php print time_dropdown('lynch','16:00'); ?></td></tr>
-  <tr><td>Night Action Deadline:</td><td><?php print time_dropdown('night','17:00'); ?></td></tr>
+  <tr><td>Dusk:</td><td><?php print time_dropdown('lynch','16:00'); ?></td></tr>
+  <tr><td>Dawn:</td><td><?php print time_dropdown('night','17:00'); ?></td></tr>
   </table>
   </div>
   <div id='cycle_lengths' class='hideDiv'>

--- a/werewolf/automod/rulesets/01_ruleset.txt
+++ b/werewolf/automod/rulesets/01_ruleset.txt
@@ -25,17 +25,17 @@ Basic 9-Player Ruleset
 [u]Evil[/u] - All evil players win if the wolves achieve parity: if at any time the number of wolves remaining equals the number of non-wolves remaining (including the sorcerer), evil wins. Howver, if one wolf is left with the hunter, then good wins. The sorcerer counts as a 'non-wolf' for these purposes.
 
 
-[b]Lynch Rules:[/b]
+[b]Day Rules:[/b]
 
-Each day players vote for one player to be lynched. The player receiving the most votes is killed. If there is a tie between two or more players, the tied player with the <tiebreaker> is killed.
+Each day players vote for one player to be killed. The player receiving the most votes is killed. If there is a tie between two or more players, the tied player with the <tiebreaker> is killed.
 
-Lynch time is <lynch> BGG time. Votes cast with this time-stamp are counted. Votes cast after this time are invalid. Votes made during the night phase are invalid.
+Dusk time is <lynch> BGG time. Votes cast with this time-stamp are counted. Votes cast after this time are invalid. Votes made during the night phase are invalid.
 
 All votes must conform to the Cassandra Vote Tally System rules. (Will be
-posted once the game starts).  If all living players vote night fall it will
-speed up the dusk.  
+posted once the game starts). If all living players vote night fall it will
+speed up the dusk.
 
-Neither the player's role or team is revealed upon lynch.
+Neither the player's role or team is revealed upon death.
 
 
 [b]Night Orders:[/b]

--- a/werewolf/automod/rulesets/153_ruleset.txt
+++ b/werewolf/automod/rulesets/153_ruleset.txt
@@ -32,7 +32,7 @@
 [u]Evil[/u] - All evil players win if the werewolf, evil priest, and wolf cub achieve parity: if at any time their number equals the number of all other player remaining (including the sorcerer), evil wins. However, if one is left with the hunter, then good wins. The sorcerer counts as a good player for these purposes.
 
 
-[b]Lynch Rules:[/b]
+[b]Day Rules:[/b]
 
 Each day players vote for one player to be lynched. The player receiving the most votes is killed. If there is a tie between two or more players, the tied player with the <tiebreaker> is killed and their side (good or evil) is revealed.
 

--- a/werewolf/cassy_vote_tally.txt
+++ b/werewolf/cassy_vote_tally.txt
@@ -23,7 +23,7 @@ see if it was marked invalid and why.
 
 6. Case does not matter and simple typos will not cause the vote to fail.
 
-7. You may [b][vote no lynch][/b] if your game allows it.
+7. You may [b][vote no kill][/b] if your game allows it.
 
 8. Non voting players will be listed in the tallies. This will only be
 correct if the Moderator notes which players have been killed (see below)
@@ -33,7 +33,7 @@ correct if the Moderator notes which players have been killed (see below)
 
 [u][b]Moderators[/b][/u]
 1. The moderator will need to post [b][Dawn][/b] when the day begins
-(after the night results are posted) and [b][Dusk][/b] when the lynch
+(after the night results are posted) and [b][Dusk][/b] when the dusk
 deadline has passed and the day is over. Votes will not be counted
 after [b][Dusk][/b] has been posted. They will be registered again
 after [b][Dawn][/b] is next posted.
@@ -47,18 +47,18 @@ Cassandra will increment an internal counter each time it sees
 3. After dusk has been posted, the Moderator may go to the game page
 on Cassandra to request a Final Tally to be posted before the normal
 scan period has elapsed (i.e. Game Y gets scanned at 45 min. after the
-hour, if it lynches at 7pm the moderator may request a tally to be
+hour, if it dusks at 7pm the moderator may request a tally to be
 posted from the game page before 7:45pm. it will also be posted
 regardless of whether or not it has been changed since the last
 posting) - Do this by clicking on the 'Force Vote Tally' link.
 
-4. You will need to note which players were killed via the lynch or at night by
+4. You will need to note which players were killed via the day vote or at night by
 either posting [b][killed jmilum][/b] in the thread, or by going to the game
 page and editing the player list. When posting in the thread, be sure to post
-[b][dusk][/b] before posting the lynch kill, and post [b][dawn][/b] before
+[b][dusk][/b] before posting the dusk kill, and post [b][dawn][/b] before
 posting the night kill.
 Example:
-A. lynch time has passed so post [b][dusk][/b]
+A. dusk has passed so post [b][dusk][/b]
 B. goto the game page and select a final tally to be posted
 C. check the final tally and post [b][killed melsana][/b]
 D. after the night deadline has passed post [b][dawn][/b]

--- a/werewolf/competition/cc_show_game_stats.php
+++ b/werewolf/competition/cc_show_game_stats.php
@@ -214,10 +214,10 @@ list($lynch,$x,$x) = split(":",$game['lynch_time']);
 list($night,$x,$x) = split(":",$game['na_deadline']);
 print "<td id='deadline_td'><div $open_comment onMouseOver='show_hint(\"Click to Change Deadlines\")' onMouseOut='hide_hint()' onClick='edit_deadline()' $close_comment>";
 if ( $lynch != "" ) {
-  print "Lynch: ".time_24($lynch)." BGG<br />";
+  print "Dusk: ".time_24($lynch)." BGG<br />";
 }
 if ( $night != "" ) {
-  print "Night Action: ".time_24($night)." BGG";
+  print "Dawn: ".time_24($night)." BGG";
 }
 print "</div>\n";
 ?>

--- a/werewolf/create_a_game.php
+++ b/werewolf/create_a_game.php
@@ -92,15 +92,15 @@ if ( s_date == "" || s_date == "yyyy-mm-dd" ) {
   return false
 }
 if ( document.getElementById('lynch').value == "" ) {
-  alert("Please fill in a Lynch time.")
+  alert("Please fill in a Dusk time.")
   return false
 }
 if ( document.getElementById('night').value == "" ) {
-  alert("Please fill in a Night Action deadline.")
+  alert("Please fill in a Dawn time.")
   return false
 }
 if ( document.getElementById('lynch').value == document.getElementById('night').value ) {
-  alert("Lynch time and Night Action Deadline can not be the same time")
+  alert("Dusk and dawn cannot be the same time")
   return false
 }
 
@@ -164,8 +164,8 @@ function show_deadlines() {
   <td>
   <div id='deadlines' class='showDiv'>
   <table cellspacing='0' cellpadding='0'>
-  <tr><td>Lynch Time:</td><td><?php print time_dropdown('lynch','16:00'); ?></td></tr>
-  <tr><td>Night Action Deadline:</td><td><?php print time_dropdown('night','17:00'); ?></td></tr>
+  <tr><td>Dusk:</td><td><?php print time_dropdown('lynch','16:00'); ?></td></tr>
+  <tr><td>Dawn:</td><td><?php print time_dropdown('night','17:00'); ?></td></tr>
   </table>
   </div>
   <div id='cycle_lengths' class='hideDiv'>

--- a/werewolf/edit_game.php
+++ b/werewolf/edit_game.php
@@ -188,10 +188,10 @@ case 's_moderator':
       list($night_length,$nlmin,$x) = split(":",$deadlines['night_length']);
       if ( $_REQUEST['speed'] == "Standard" ) {
         if ( $lynch != "" ) {
-          print "Lynch: ".time_24($lynch,$lmin)." BGG<br />";
+          print "Dusk: ".time_24($lynch,$lmin)." BGG<br />";
         }
         if ( $night != "" ) {
-          print "Night Action: ".time_24($night,$nmin)." BGG";
+          print "Dawn: ".time_24($night,$nmin)." BGG";
         }
       } else {
         print "Day Length: $day_length:$dlmin <br />\n";
@@ -224,8 +224,8 @@ case 's_moderator':
       if ( $speed == "Standard" ) { 
          list($lynch,$lmin,$x) = split(":",$_REQUEST['lynch']);
          list($night,$nmin,$x) = split(":",$_REQUEST['night']);    
-         print "Lynch: ".time_24($lynch,$lmin)." BGG<br />";
-         print "Night Action: ".time_24($night,$nmin)." BGG";
+         print "Dusk: ".time_24($lynch,$lmin)." BGG<br />";
+         print "Dawn: ".time_24($night,$nmin)." BGG";
       } else {
          print "Day Length: ".$_REQUEST['day_length']."<br />\n";
          print "Night Length: ".$_REQUEST['night_length']."<br />\n";

--- a/werewolf/edit_game_functions.php
+++ b/werewolf/edit_game_functions.php
@@ -203,8 +203,8 @@ function edit_deadline($game_id) {
   #list($night,$nmin) = split(":",$night_db);
   $output .= "<table>\n";
   if ( $speed == "Standard" ) {
-    $output .= "<tr><td>Lynch:</td><td>".time_dropdown('lynch',$lynch,false,false)."</td></tr>\n";
-    $output .= "<tr><td>Night Action:</td><td>".time_dropdown('night',$night,false,false)."</td></tr>\n";
+    $output .= "<tr><td>Dusk:</td><td>".time_dropdown('lynch',$lynch,false,false)."</td></tr>\n";
+    $output .= "<tr><td>Dawn:</td><td>".time_dropdown('night',$night,false,false)."</td></tr>\n";
     $output .= "<input type='hidden' name='day_length' value='$day_length' />\n";
     $output .= "<input type='hidden' name='night_length' value='$night_length' />\n";
   } else {

--- a/werewolf/game_action.php
+++ b/werewolf/game_action.php
@@ -13,7 +13,7 @@ if ( isset($_POST['submit']) || isset($_POST['cancel'])) {
   $result = mysql_query($sql);
   $game_phase = mysql_result($result,0,0);
   if ( $game_phase ==  'night' && $_POST['target_id'] == '0' ) {
-    error("Please input the players name now that the game is in night phase rather than the generic 'Lynch Victim' as your target");
+    error("Please input the players name now that the game is in night phase rather than the generic 'Daykill Victim' as your target");
   }
   $sql = sprintf("insert into Game_orders (id, user_id, game_id, `desc`, day) values (NULL, %s,%s,%s,%s)",quote_smart($_POST['user_id']),quote_smart($_POST['game_id']),quote_smart($_POST['desc']),quote_smart($_POST['day']));
   $result = mysql_query($sql);
@@ -29,7 +29,7 @@ if ( isset($_POST['submit']) || isset($_POST['cancel'])) {
         $target = mysql_result($result,0,0);
         $message .= $target." ";
 	  } else {
-        $message .= "Lynch Victim ";
+        $message .= "Daykill Victim ";
 	  }
 	}
   }

--- a/werewolf/game_chat_functions.php
+++ b/werewolf/game_chat_functions.php
@@ -185,13 +185,13 @@ function game_order_logx($user_id,$game_id,$mod) {
   }
   if ($mod)
   {
-    $sql = sprintf("select p.id as user_id, p.name as user, ga_group, Roles.`type`, `desc`, if(cancel is null, concat(coalesce(concat(if(target_id=0,'Lynch Victim',t.name),' '),''),user_text),'canceled') as target, last_updated, Game_orders.day as day from Game_orders left join Users t on t.id=Game_orders.target_id, Users p, Roles, Players_all, Players where Game_orders.user_id=p.id and Players_all.original_id=Players.user_id and Players_all.user_id=Game_orders.user_id and Players_all.game_id=Game_orders.game_id and Players.game_id=Players_all.game_id and Roles.id=Players.role_id and Game_orders.game_id=%s order by last_updated desc",quote_smart($game_id));
+    $sql = sprintf("select p.id as user_id, p.name as user, ga_group, Roles.`type`, `desc`, if(cancel is null, concat(coalesce(concat(if(target_id=0,'Daykill Victim',t.name),' '),''),user_text),'canceled') as target, last_updated, Game_orders.day as day from Game_orders left join Users t on t.id=Game_orders.target_id, Users p, Roles, Players_all, Players where Game_orders.user_id=p.id and Players_all.original_id=Players.user_id and Players_all.user_id=Game_orders.user_id and Players_all.game_id=Game_orders.game_id and Players.game_id=Players_all.game_id and Roles.id=Players.role_id and Game_orders.game_id=%s order by last_updated desc",quote_smart($game_id));
   } else {
     if ($group != "")
     {
-      $sql = sprintf("select p.id as user_id, p.name as user, ga_group, Roles.`type`, `desc`, if(cancel is null, concat(coalesce(concat(if(target_id=0,'Lynch Victim',t.name),' '),''),user_text),'canceled') as target, last_updated, Game_orders.day as day from Game_orders left join Users t on t.id=Game_orders.target_id, Users p, Roles, Players_all, Players where Game_orders.user_id=p.id and Players_all.original_id=Players.user_id and Players_all.user_id=Game_orders.user_id and Players_all.game_id=Game_orders.game_id and Players.game_id=Players_all.game_id and Roles.id=Players.role_id and Game_orders.game_id=%s and (p.id=%s or ga_group=%s) order by last_updated desc",quote_smart($game_id), quote_smart($user_id), quote_smart($group));
+      $sql = sprintf("select p.id as user_id, p.name as user, ga_group, Roles.`type`, `desc`, if(cancel is null, concat(coalesce(concat(if(target_id=0,'Daykill Victim',t.name),' '),''),user_text),'canceled') as target, last_updated, Game_orders.day as day from Game_orders left join Users t on t.id=Game_orders.target_id, Users p, Roles, Players_all, Players where Game_orders.user_id=p.id and Players_all.original_id=Players.user_id and Players_all.user_id=Game_orders.user_id and Players_all.game_id=Game_orders.game_id and Players.game_id=Players_all.game_id and Roles.id=Players.role_id and Game_orders.game_id=%s and (p.id=%s or ga_group=%s) order by last_updated desc",quote_smart($game_id), quote_smart($user_id), quote_smart($group));
     } else {
-      $sql = sprintf("select p.id as user_id, p.name as user, ga_group, Roles.`type`, `desc`, if(cancel is null, concat(coalesce(concat(if(target_id=0,'Lynch Victim',t.name),' '),''),user_text),'canceled') as target, last_updated, Game_orders.day as day from Game_orders left join Users t on t.id=Game_orders.target_id, Users p, Roles, Players_all, Players where Game_orders.user_id=p.id and Players_all.original_id=Players.user_id and Players_all.user_id=Game_orders.user_id and Players_all.game_id=Game_orders.game_id and Players.game_id=Players_all.game_id and Roles.id=Players.role_id and Game_orders.game_id=%s and p.id=%s order by last_updated desc",quote_smart($game_id), quote_smart($user_id));
+      $sql = sprintf("select p.id as user_id, p.name as user, ga_group, Roles.`type`, `desc`, if(cancel is null, concat(coalesce(concat(if(target_id=0,'Daykill Victim',t.name),' '),''),user_text),'canceled') as target, last_updated, Game_orders.day as day from Game_orders left join Users t on t.id=Game_orders.target_id, Users p, Roles, Players_all, Players where Game_orders.user_id=p.id and Players_all.original_id=Players.user_id and Players_all.user_id=Game_orders.user_id and Players_all.game_id=Game_orders.game_id and Players.game_id=Players_all.game_id and Roles.id=Players.role_id and Game_orders.game_id=%s and p.id=%s order by last_updated desc",quote_smart($game_id), quote_smart($user_id));
     }
   }
   $result = mysql_query($sql);
@@ -358,7 +358,7 @@ function game_order_input($user_id,$game_id,$day) {
 	    $result = mysql_query($sql);
         $count = 0;
 		if ( $actions['game_action'] == "dead" && $game_phase == "day") {
-          $output .= "<option value='0'>Today's Lynch Victim</option>";
+          $output .= "<option value='0'>Today's Daykill Victim</option>";
 		  $count++;
 		}
 	    while ( $user = mysql_fetch_array($result) ) {
@@ -421,7 +421,7 @@ function game_order_sumary($user_id,$game_id,$day) {
 		$sql2 = sprintf("select distinct `desc` from Game_orders, Players, Players_all where Game_orders.user_id=Players_all.user_id and Game_orders.game_id=Players_all.game_id and Players_all.original_id=Players.user_id and Players_all.game_id=Players.game_id and Game_orders.game_id=%s and Players.ga_group=%s order by `desc`",quote_smart($game_id),quote_smart($player['ga_group']));
 		$result2 = mysql_query($sql2);
 		while ( $action = mysql_fetch_array($result2) ) {
-		  $sql3 = sprintf("select u.name as player, concat(coalesce(concat(if(target_id=0,'Lynch Victim',t.name),' '),''),user_text) as target, cancel from Game_orders left join Users t on t.id=Game_orders.target_id , Users u, Players, Players_all where u.id=Game_orders.user_id and Players.user_id=Players_all.original_id and Players_all.user_id=Game_orders.user_id and Players.game_id=Players_all.game_id and Players.game_id=Game_orders.game_id and Game_orders.game_id=%s and `desc`=%s and day=%s and ga_group=%s order by last_updated desc limit 0, 1",quote_smart($game_id),quote_smart($action['desc']),quote_smart($day),quote_smart($player['ga_group']));
+		  $sql3 = sprintf("select u.name as player, concat(coalesce(concat(if(target_id=0,'Daykill Victim',t.name),' '),''),user_text) as target, cancel from Game_orders left join Users t on t.id=Game_orders.target_id , Users u, Players, Players_all where u.id=Game_orders.user_id and Players.user_id=Players_all.original_id and Players_all.user_id=Game_orders.user_id and Players.game_id=Players_all.game_id and Players.game_id=Game_orders.game_id and Game_orders.game_id=%s and `desc`=%s and day=%s and ga_group=%s order by last_updated desc limit 0, 1",quote_smart($game_id),quote_smart($action['desc']),quote_smart($day),quote_smart($player['ga_group']));
 	      $result3 = mysql_query($sql3);
 	      while ( $order = mysql_fetch_array($result3) ) {
 		    if ( $order['cancel'] == "" ) {
@@ -435,7 +435,7 @@ function game_order_sumary($user_id,$game_id,$day) {
 	  $sql2 = sprintf("select distinct `desc` from Game_orders where game_id=%s and user_id=%s",quote_smart($game_id),quote_smart($player['id']));
 	  $result2 = mysql_query($sql2);
 	  while ( $action = mysql_fetch_array($result2) ) {
-	    $sql3 = sprintf("select concat(coalesce(concat(if(target_id=0,'Lynch Victim',t.name),' '),''),user_text) as target, cancel from Game_orders left join Users t on t.id=Game_orders.target_id where Game_orders.game_id=%s and Game_orders.user_id=%s and `desc`=%s and day=%s order by last_updated desc limit 0, 1",quote_smart($game_id),quote_smart($player['id']),quote_smart($action['desc']),quote_smart($day));
+	    $sql3 = sprintf("select concat(coalesce(concat(if(target_id=0,'Daykill Victim',t.name),' '),''),user_text) as target, cancel from Game_orders left join Users t on t.id=Game_orders.target_id where Game_orders.game_id=%s and Game_orders.user_id=%s and `desc`=%s and day=%s order by last_updated desc limit 0, 1",quote_smart($game_id),quote_smart($player['id']),quote_smart($action['desc']),quote_smart($day));
         $result3 = mysql_query($sql3);
         while ( $order = mysql_fetch_array($result3) ) {
 		  if ( $order['cancel'] == "" ) {
@@ -461,7 +461,7 @@ function game_order_log($user_id,$game_id,$day) {
 	  $group = mysql_result($result,0,0);
 	}
   }
-  $sql = sprintf("select p.id as user_id, p.name as user, ga_group, Roles.`type`, `desc`, if(cancel is null, concat(coalesce(concat(if(target_id=0,'Lynch Victim',t.name),' '),''),user_text),'canceled') as target, last_updated from Game_orders left join Users t on t.id=Game_orders.target_id, Users p, Roles, Players_all, Players where Game_orders.user_id=p.id and Players_all.original_id=Players.user_id and Players_all.user_id=Game_orders.user_id and Players_all.game_id=Game_orders.game_id and Players.game_id=Players_all.game_id and Roles.id=Players.role_id and Game_orders.game_id=%s and Game_orders.day=%s order by last_updated desc",quote_smart($game_id),quote_smart($day));
+  $sql = sprintf("select p.id as user_id, p.name as user, ga_group, Roles.`type`, `desc`, if(cancel is null, concat(coalesce(concat(if(target_id=0,'Daykill Victim',t.name),' '),''),user_text),'canceled') as target, last_updated from Game_orders left join Users t on t.id=Game_orders.target_id, Users p, Roles, Players_all, Players where Game_orders.user_id=p.id and Players_all.original_id=Players.user_id and Players_all.user_id=Game_orders.user_id and Players_all.game_id=Game_orders.game_id and Players.game_id=Players_all.game_id and Roles.id=Players.role_id and Game_orders.game_id=%s and Game_orders.day=%s order by last_updated desc",quote_smart($game_id),quote_smart($day));
   $result = mysql_query($sql);
   $count = mysql_num_rows($result);
   if ( $count == 0 ) { return; }

--- a/werewolf/game_page_functions.php
+++ b/werewolf/game_page_functions.php
@@ -292,15 +292,15 @@ function show_deadlines($game_id,$edit='false') {
   list($lynch,$x,$x) = split(":",$game['lynch_time']);
   list($night,$x,$x) = split(":",$game['na_deadline']);
   $content = "";
-  if ( $lynch != "" ) { $content .= "Lynch: ".time_24($lynch)." BGG<br />"; }
-  if ( $night != "" ) { $content .= "Night Action: ".time_24($night)." BGG"; }
+  if ( $lynch != "" ) { $content .= "Dusk: ".time_24($lynch)." BGG<br />"; }
+  if ( $night != "" ) { $content .= "Dawn: ".time_24($night)." BGG"; }
   $output .= create_edit_div($edit,'deadline_div2',"Click to Edit Deadlines",'get_edit_form("deadline_form")',$content);
   if ( $lynch != "" ) {
     $sql = sprintf("SELECT concat_ws(', ',if(sun, 'Sun', null),if(mon, 'Mon', null), if(tue, 'Tue', null), if(wed, 'Wed', null), if(thu, 'Thu', null), if(fri, 'Fri', null), if(sat, 'Sat', null)) as lynch_days from Auto_dusk where  game_id=%s",quote_smart($game_id));
     $result = mysql_query($sql);
     if ( mysql_num_rows($result) == 1 ) {
       $lynch_days = mysql_result($result,0,0);
-      $output .= "<tr><td><b>Lynch Days:</b></td><td>$lynch_days</td></tr>\n";
+      $output .= "<tr><td><b>Game Days:</b></td><td>$lynch_days</td></tr>\n";
     }
   }
 
@@ -398,7 +398,7 @@ function create_mod_controls($game_id,$status,$chats) {
     if ( $game['auto_vt'] == "No" ) {
       $output .= "<div><a href='javascript:get_modcontrol_form(\"vote_tally_form\")'>Activate Auto Vote Tally</a></div>\n";
     } else {
-      $output .= "<div><a href='javascript:submit_vote_tally(\"retrieve\")'>Retrieve Final Lynch Time Vote</a></div>\n";
+      $output .= "<div><a href='javascript:submit_vote_tally(\"retrieve\")'>Retrieve Final Dusk Time Vote</a></div>\n";
     }
     $output .=  "<div><a href='$domain/configure_chat.php?game_id=".$game['id']."'>Activate/Configure Game Communications System</a></div>\n";
     if ( $chats > 0 ) {
@@ -657,8 +657,8 @@ function deadline_form($game_id) {
   list($lynch,$x) = split(":",$lynch_db);
   list($night,$x) = split(":",$night_db);
   $output .= "<table>\n";
-  $output .= "<tr><td>Lynch:</td><td>".time_dropdown_old('lynch',$lynch)."</td></tr>\n";
-  $output .= "<tr><td>Night Action:</td><td>".time_dropdown_old('night',$night)."</td></tr>\n";
+  $output .= "<tr><td>Dusk:</td><td>".time_dropdown_old('lynch',$lynch)."</td></tr>\n";
+  $output .= "<tr><td>Dawn:</td><td>".time_dropdown_old('night',$night)."</td></tr>\n";
   $output .= "<tr><td colspan='2' align='center'><input type='button' name='submit' value='submit' onClick='submit_deadline()' /><input type='button' name='cancel' value='cancel' onClick='clear_edit()' /></td></tr>\n";
   $output .= "</table>\n";
   $output .= "</form>\n";
@@ -874,8 +874,8 @@ function vote_tally_form($game_id) {
   $options['lhv'] = "Longest Held Vote";
   $output .= create_dropdown('tieb','lhlv',$options);
   $output .= "<input type='button' value='submit' onClick='javascript:submit_vote_tally(\"activate\")'></form>";
-  $output .= "<br>Allow nightfall votes? <input type='checkbox' name='allow_nightfall' id='allow_nightfall' checked=1 />";
-  $output .= "<br>Allow No Lynch votes? <input type='checkbox' name='allow_nolynch' id='allow_nolynch' checked=1 />";  
+  $output .= "<br>Allow Nightfall votes? <input type='checkbox' name='allow_nightfall' id='allow_nightfall' checked=1 />";
+  $output .= "<br>Allow No Kill votes? <input type='checkbox' name='allow_nolynch' id='allow_nolynch' checked=1 />";  
   return $output;
 }
 

--- a/werewolf/mod_control.js
+++ b/werewolf/mod_control.js
@@ -51,7 +51,7 @@ xmlHttp.send(null)
 function activate_vt() {
   myelement = document.getElementById("control_space")
   myelement.style.visibility='visible'
-  myelement.innerHTML = "<form name='tiebreaker'>Choose a Tie Breaker:<br/><select name='tieb'><option value='lhlv' />Longest Held Last Vote<option value='lhv' />Longest Held Vote</select><br />Allow Nightfall votes? <input type='checkbox' name='allow_nightfall' id='allow_nightfall' checked=1 /><br />Allow No Lynch votes? <input type='checkbox' name='allow_nolynch' id='allow_nolynch' checked=1 /><br /><input type='button' value='submit' onClick='javascript:submit_activate_vt()'></form>"
+  myelement.innerHTML = "<form name='tiebreaker'>Choose a Tie Breaker:<br/><select name='tieb'><option value='lhlv' />Longest Held Last Vote<option value='lhv' />Longest Held Vote</select><br />Allow Nightfall votes? <input type='checkbox' name='allow_nightfall' id='allow_nightfall' checked=1 /><br />Allow No Kill votes? <input type='checkbox' name='allow_nolynch' id='allow_nolynch' checked=1 /><br /><input type='button' value='submit' onClick='javascript:submit_activate_vt()'></form>"
 }
 
 function submit_activate_vt() {

--- a/werewolf/move_to_signup.php
+++ b/werewolf/move_to_signup.php
@@ -81,7 +81,7 @@ if ( s_date == "" || s_date == "yyyy-mm-dd" || s_date == "0000-00-00") {
   return false
 }
 if ( document.getElementById('lynch').value == document.getElementById('night').value ) {
-  alert("Lynch time and Night Action Deadline can not be the same time")
+  alert("Dusk and Dawn cannot be the same time")
   return false
 }
 
@@ -111,8 +111,8 @@ return true
 <tr><td align='right'>Game Name:</td><td><input type='text' name='title' value='<?=$game['title'];?>' /></td></tr>
 <tr><td align='right'>BGG Thread ID:</td><td><input type='text' name='thread_id' /></td></tr>
 <tr><td align='right'>Start Date:</td><td><input type='text' name='start_date' value='<?=$game['start_date'];?>'/></td></tr>
-<tr><td align='right'>Lynch Time:</td><td><?php print time_dropdown_old('lynch'); ?></td></tr>
-<tr><td align='right'>Night Action Deadline:</td><td><?php print time_dropdown_old('night'); ?></td></tr>
+<tr><td align='right'>Dusk:</td><td><?php print time_dropdown_old('lynch'); ?></td></tr>
+<tr><td align='right'>Dawn:</td><td><?php print time_dropdown_old('night'); ?></td></tr>
 <tr><td align='right'>Aprox. Length:</td><td><select name='aprox_length'>
 <?php
 $selected7 = "";

--- a/werewolf/show_game_stats.php
+++ b/werewolf/show_game_stats.php
@@ -220,10 +220,10 @@ list($night_length,$nlmin,$x) = split(":",$game['night_length']);
 print "<td id='deadline_td'><div $open_comment onMouseOver='show_hint(\"Click to Change Deadlines\")' onMouseOut='hide_hint()' onClick='edit_deadline()' $close_comment>";
 if ( $game['deadline_speed'] == "Standard" ) {
   if ( $lynch != "" ) {
-    print "Lynch: ".time_24($lynch,$lmin)." BGG<br />";
+    print "Dusk: ".time_24($lynch,$lmin)." BGG<br />";
   }
   if ( $night != "" ) {
-    print "Night Action: ".time_24($night,$nmin)." BGG";
+    print "Dawn: ".time_24($night,$nmin)." BGG";
   }
 } else {
   print "Day Length: $day_length:$dlmin <br />\n";
@@ -238,7 +238,7 @@ if ( $lynch != "" ) {
   $result = mysql_query($sql);
   if ( mysql_num_rows($result) == 1 ) {
     $lynch_days = mysql_result($result,0,0);
-	print"<tr><td><b>Lynch Days:</b></td><td>$lynch_days</td></tr>\n";
+	print"<tr><td><b>Game Days:</b></td><td>$lynch_days</td></tr>\n";
   }
  
 }

--- a/werewolf/vote_tally.php
+++ b/werewolf/vote_tally.php
@@ -31,7 +31,7 @@ $action = $_GET['action'];
 	    $message .= "Your Moderator has chosen to use the Longest Held Last Vote method for a tiebreaker - This is just for Cassandra system, and there may be a different tiebreaker specified by your Moderator in the ruleset.\n";
 	  }
 	  $message .= "Your Moderator has chosen to [b]" . ($nf == "No" ?  "dis" : "") . "allow[/b] Nightfall votes.\n";
-	  $message .= "Your Moderator has chosen to [b]" . ($nl == "No" ?  "dis" : "") . "allow[/b] No Lynch votes.\n\n";
+	  $message .= "Your Moderator has chosen to [b]" . ($nl == "No" ?  "dis" : "") . "allow[/b] No Kill votes.\n\n";
 	  
 	  $message .= "Vote Log Page: http://cassandrawerewolf.com/game/".$game['thread_id']."/votes\n";
 	  $message .= "Vote Tally Page: http://cassandrawerewolf.com/game/".$game['thread_id']."/tally\n";


### PR DESCRIPTION
This update replaces instance of the word "lynch" in the UI with alternative terminology: day kill, no kill, dusk.

It also renames "Night action deadlines" to "Dawn" for better consistency with Dusk.